### PR TITLE
Patch strings

### DIFF
--- a/src/gnatcoll-atomic.ads
+++ b/src/gnatcoll-atomic.ads
@@ -92,6 +92,12 @@ package GNATCOLL.Atomic is
    --      4 (thread 1 has read and incremented, then thread 2)
    --  If you use the other operations above, you always end up with 4.
 
+   function ">" (Left, Right : Atomic_Counter) return Boolean
+      is (System.Atomic_Counters.">" (Left, Right));
+   --  Compare two counters.
+   --  Note that by the time this function returns, and in a multi threaded
+   --  application, either of the two counters might have changed.
+
    function "="
       (Left, Right : Atomic_Counter) return Boolean
       renames System.Atomic_Counters."=";

--- a/src/gnatcoll-counters.adb
+++ b/src/gnatcoll-counters.adb
@@ -1,0 +1,97 @@
+------------------------------------------------------------------------------
+--                             G N A T C O L L                              --
+--                                                                          --
+--                     Copyright (C) 2018-2018, AdaCore                     --
+--                                                                          --
+-- This library is free software;  you can redistribute it and/or modify it --
+-- under terms of the  GNU General Public License  as published by the Free --
+-- Software  Foundation;  either version 3,  or (at your  option) any later --
+-- version. This library is distributed in the hope that it will be useful, --
+-- but WITHOUT ANY WARRANTY;  without even the implied warranty of MERCHAN- --
+-- TABILITY or FITNESS FOR A PARTICULAR PURPOSE.                            --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+------------------------------------------------------------------------------
+
+package body GNATCOLL.Counters is
+
+   One_Automatic : constant Automatic_Counter :=
+      (if Application_Uses_Tasks
+       then (Atomic => True,  A_Value => 1)
+       else (Atomic => False, N_Value => 1));
+
+   ----------------
+   -- Set_To_One --
+   ----------------
+
+   procedure Set_To_One (Val : out GNATCOLL.Atomic.Atomic_Counter) is
+   begin
+      Val := 1;
+   end Set_To_One;
+
+   procedure Set_To_One (Val : out Non_Atomic_Counter) is
+   begin
+      Val := 1;
+   end Set_To_One;
+
+   procedure Set_To_One (Val : out Automatic_Counter) is
+   begin
+      Val := One_Automatic;
+   end Set_To_One;
+
+   -----------------
+   -- Set_To_Zero --
+   -----------------
+
+   procedure Set_To_Zero (Val : out GNATCOLL.Atomic.Atomic_Counter) is
+   begin
+      Val := Atomic_Zero;
+   end Set_To_Zero;
+
+   procedure Set_To_Zero (Val : out Non_Atomic_Counter) is
+   begin
+      Val := Non_Atomic_Zero;
+   end Set_To_Zero;
+
+   procedure Set_To_Zero (Val : out Automatic_Counter) is
+   begin
+      Val := Automatic_Zero;
+   end Set_To_Zero;
+
+   ---------------
+   -- Increment --
+   ---------------
+
+   procedure Increment (Val : aliased in out Non_Atomic_Counter) is
+   begin
+      Val := Val + 1;
+   end Increment;
+
+   procedure Increment (Val : aliased in out Automatic_Counter) is
+   begin
+      case Application_Uses_Tasks is
+         when True  => GNATCOLL.Atomic.Increment (Val.A_Value);
+         when False => Val.N_Value := Val.N_Value + 1;
+      end case;
+   end Increment;
+
+   ---------------
+   -- Decrement --
+   ---------------
+
+   function Decrement
+      (Val : aliased in out Non_Atomic_Counter) return Boolean is
+   begin
+      Val := Val - 1;
+      return Val = 0;
+   end Decrement;
+
+end GNATCOLL.Counters;

--- a/src/gnatcoll-counters.adb
+++ b/src/gnatcoll-counters.adb
@@ -71,11 +71,13 @@ package body GNATCOLL.Counters is
    ---------------
 
    procedure Increment (Val : aliased in out Non_Atomic_Counter) is
+      pragma Suppress (Overflow_Check);
    begin
       Val := Val + 1;
    end Increment;
 
    procedure Increment (Val : aliased in out Automatic_Counter) is
+      pragma Suppress (Overflow_Check);
    begin
       case Application_Uses_Tasks is
          when True  => GNATCOLL.Atomic.Increment (Val.A_Value);
@@ -88,7 +90,9 @@ package body GNATCOLL.Counters is
    ---------------
 
    function Decrement
-      (Val : aliased in out Non_Atomic_Counter) return Boolean is
+      (Val : aliased in out Non_Atomic_Counter) return Boolean
+   is
+      pragma Suppress (Overflow_Check);
    begin
       Val := Val - 1;
       return Val = 0;

--- a/src/gnatcoll-counters.ads
+++ b/src/gnatcoll-counters.ads
@@ -1,0 +1,168 @@
+------------------------------------------------------------------------------
+--                             G N A T C O L L                              --
+--                                                                          --
+--                     Copyright (C) 2018-2018, AdaCore                     --
+--                                                                          --
+-- This library is free software;  you can redistribute it and/or modify it --
+-- under terms of the  GNU General Public License  as published by the Free --
+-- Software  Foundation;  either version 3,  or (at your  option) any later --
+-- version. This library is distributed in the hope that it will be useful, --
+-- but WITHOUT ANY WARRANTY;  without even the implied warranty of MERCHAN- --
+-- TABILITY or FITNESS FOR A PARTICULAR PURPOSE.                            --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+------------------------------------------------------------------------------
+
+--  A package that provides either atomic counters, or non-atomic counters.
+
+with GNATCOLL.Atomic;
+
+pragma Warnings (Off, "* is an internal GNAT unit");
+with System.Soft_Links;               use System.Soft_Links;
+pragma Warnings (On, "* is an internal GNAT unit");
+
+package GNATCOLL.Counters is
+
+   generic
+      type Counter is limited private;
+
+      with procedure Increment (Val : aliased in out Counter);
+      --  Increment Val by 1
+
+      with function Decrement (Val : aliased in out Counter) return Boolean;
+      --  Decrement Val by 1.
+      --  Returns True if the new value is 0.
+
+      with procedure Set_To_One (Val : out Counter) is <>;
+      with function Greater_Than_One (Val : Counter) return Boolean is <>;
+      --  Set the counter to 1
+
+      with procedure Set_To_Zero (Val : out Counter) is <>;
+      with function Is_Zero (Val : Counter) return Boolean is <>;
+      --  A value that will not be reached in the normal flow of things. This
+      --  is used to indicate that a counter is uninitialized, or as a special
+      --  markup for instance.  This must be return False with
+      --  Greater_Than_One.
+
+      Task_Safe : Boolean;
+      --  Whether these counters are thread safe
+
+      Is_Lock_Free : Boolean;
+      --  Whether the counter is implement with lock free operations
+      --  (compare-and-swap,...), or via controlled types (with locking)
+
+   package Signature is
+      Is_Task_Safe : constant Boolean := Task_Safe;
+      --  Make available to users of the package
+
+   end Signature;
+
+   ---------------------
+   -- Atomic counters --
+   ---------------------
+
+   Atomic_Zero : constant GNATCOLL.Atomic.Atomic_Counter;
+   procedure Set_To_One
+      (Val : out GNATCOLL.Atomic.Atomic_Counter) with Inline;
+   procedure Set_To_Zero
+      (Val : out GNATCOLL.Atomic.Atomic_Counter) with Inline;
+   function  Is_Zero (Val : GNATCOLL.Atomic.Atomic_Counter) return Boolean
+      is (GNATCOLL.Atomic."=" (Val, Atomic_Zero));
+   function Greater_Than_One (Val : GNATCOLL.Atomic.Atomic_Counter)
+      return Boolean
+      is (GNATCOLL.Atomic.">" (Val, 1));
+
+   package Atomic_Counters is new Signature
+      (Counter      => GNATCOLL.Atomic.Atomic_Counter,
+       Increment    => GNATCOLL.Atomic.Increment,
+       Decrement    => GNATCOLL.Atomic.Decrement,
+       Task_Safe    => True,
+       Is_Lock_Free => GNATCOLL.Atomic.Is_Lock_Free);
+
+   -------------------------
+   -- Non atomic counters --
+   -------------------------
+
+   type Non_Atomic_Counter is new Natural;
+   Non_Atomic_Zero : constant Non_Atomic_Counter;
+   procedure Increment (Val : aliased in out Non_Atomic_Counter)
+      with Inline;
+   function Decrement (Val : aliased in out Non_Atomic_Counter) return Boolean
+      with Inline;
+   procedure Set_To_One (Val : out Non_Atomic_Counter) with Inline;
+   procedure Set_To_Zero (Val : out Non_Atomic_Counter) with Inline;
+   function  Is_Zero (Val : Non_Atomic_Counter) return Boolean
+      is (Val = Non_Atomic_Zero);
+   function Greater_Than_One (Val : Non_Atomic_Counter) return Boolean
+      is (Val > 1);
+
+   package Non_Atomic_Counters is new Signature
+      (Counter      => Non_Atomic_Counter,
+       Increment    => Increment,
+       Decrement    => Decrement,
+       Task_Safe    => False,
+       Is_Lock_Free => True);
+
+   ------------------------
+   -- Automatic counters --
+   ------------------------
+   --  At the cost of a slightly bigger size, these counters will either be
+   --  atomic (if the tasking runtime was initialized) or not.
+
+   Application_Uses_Tasks : constant Boolean :=
+      System.Soft_Links.Lock_Task /= System.Soft_Links.Task_Lock_NT'Access;
+   --  Whether the tasking run time has been initialized.
+
+   type Automatic_Counter (Atomic : Boolean := True) is record
+      case Atomic is
+         when True  => A_Value : aliased GNATCOLL.Atomic.Atomic_Counter;
+         when False => N_Value : aliased Non_Atomic_Counter;
+      end case;
+   end record
+   with Unchecked_Union;
+
+   Automatic_Zero : constant Automatic_Counter;
+
+   procedure Set_To_One (Val : out Automatic_Counter) with Inline;
+   procedure Set_To_Zero (Val : out Automatic_Counter) with Inline;
+   function  Is_Zero (Val : Automatic_Counter) return Boolean
+      is (case Application_Uses_Tasks is
+          when True  => GNATCOLL.Atomic."=" (Val.A_Value, 0),
+          when False => Val.N_Value = 0);
+   procedure Increment (Val : aliased in out Automatic_Counter)
+      with Inline;
+   function Decrement (Val : aliased in out Automatic_Counter) return Boolean
+      is (case Application_Uses_Tasks is
+          when True  => GNATCOLL.Atomic.Decrement (Val.A_Value),
+          when False => Decrement (Val.N_Value));
+   function Greater_Than_One (Val : Automatic_Counter) return Boolean
+      is (case Application_Uses_Tasks is
+          when True  => GNATCOLL.Atomic.">" (Val.A_Value, 1),
+          when False => Val.N_Value > 1);
+
+   package Automatic_Counters is new Signature
+      (Counter      => Automatic_Counter,
+       Increment    => Increment,
+       Decrement    => Decrement,
+       Task_Safe    => Application_Uses_Tasks,
+       Is_Lock_Free => not Application_Uses_Tasks
+          or else GNATCOLL.Atomic.Is_Lock_Free);
+
+private
+
+   Non_Atomic_Zero : constant Non_Atomic_Counter := 0;
+   Atomic_Zero : constant GNATCOLL.Atomic.Atomic_Counter := 0;
+   Automatic_Zero : constant Automatic_Counter :=
+      (if Application_Uses_Tasks
+       then ((Atomic => True,  A_Value => 0))
+       else ((Atomic => False, N_Value => 0)));
+
+end GNATCOLL.Counters;

--- a/src/gnatcoll-strings.ads
+++ b/src/gnatcoll-strings.ads
@@ -25,6 +25,7 @@
 --  copy-on-write.
 --  See details in gnatcoll-strings_impl.ads
 
+with GNATCOLL.Counters;
 with GNATCOLL.Strings_Impl;
 with Ada.Characters.Handling;    use Ada.Characters.Handling;
 
@@ -32,4 +33,5 @@ package GNATCOLL.Strings is
    new GNATCOLL.Strings_Impl.Strings
       (SSize            => GNATCOLL.Strings_Impl.Optimal_String_Size,
        Character_Type   => Character,
-       Character_String => String);
+       Character_String => String,
+       Counters         => GNATCOLL.Counters.Automatic_Counters);

--- a/src/gnatcoll-strings_impl.adb
+++ b/src/gnatcoll-strings_impl.adb
@@ -302,24 +302,25 @@ package body GNATCOLL.Strings_Impl is
                   --  Nothing to do, not shared and already has right capacity
                   null;
 
-               --  Would we have enough space if we move characters so that
-               --  First becomes 1 ?
+               else
+                  --  Move back all characters to "first=1"
 
-               elsif Capacity <= Current then
-                  Old := Natural (Self.Data.Big.Size);
-                  Tmp.Bytes (1 .. Old) := Tmp.Bytes (First .. First - 1 + Old);
-                  Self.Data.Big.First := 1;
+                  if First /= 1 then
+                     Old := Natural (Self.Data.Big.Size);
+                     Tmp.Bytes (1 .. Old) :=
+                        Tmp.Bytes (First .. First - 1 + Old);
+                     Self.Data.Big.First := 1;
+                  end if;
 
-               --  Do we need to extend the memory ?
-
-               elsif Current < Capacity then
-                  New_Size := Growth_Strategy (Current, Capacity);
-                  Store_Capacity (Self, New_Size);
-                  Self.Data.Big.Data := Convert
-                     (System.Memory.Realloc
-                       (Convert (Tmp),
-                        size_t (New_Size) * Bytes_Per_Char +
-                        Extra_Header_Size));
+                  if Capacity > Current then
+                     New_Size := Growth_Strategy (Current, Capacity);
+                     Store_Capacity (Self, New_Size);
+                     Self.Data.Big.Data := Convert
+                        (System.Memory.Realloc
+                          (Convert (Tmp),
+                           size_t (New_Size) * Bytes_Per_Char +
+                           Extra_Header_Size));
+                  end if;
                end if;
             end;
 

--- a/src/gnatcoll-strings_impl.adb
+++ b/src/gnatcoll-strings_impl.adb
@@ -1844,6 +1844,11 @@ package body GNATCOLL.Strings_Impl is
       begin
          Get_String (Self, S, L);
 
+         --  Special case for empty strings: do not raise Index_Error
+         if L = 0 then
+            return 0;
+         end if;
+
          if Low > L then
             raise Ada.Strings.Index_Error with Low'Img & " >" & L'Img;
          end if;

--- a/src/gnatcoll-strings_impl.adb
+++ b/src/gnatcoll-strings_impl.adb
@@ -121,7 +121,7 @@ package body GNATCOLL.Strings_Impl is
          (Self         : in out XString;
           Data         : Big_String_Data_Access;
           Min_Capacity : String_Size)
-         with Pre => Self.Data.Small.Is_Big, Inline;
+         with Pre => Self.Data.Small.Is_Big, No_Inline;
       --  Set the big string data, copying from Data.
       --  We copy the data from the parameter and not from Self.Data.Big.Data
       --  because the latter might already have been set to null at that
@@ -193,6 +193,7 @@ package body GNATCOLL.Strings_Impl is
       ------------
 
       overriding procedure Adjust (Self : in out XString) is
+         pragma Suppress (Access_Check);
       begin
          if not Self.Data.Small.Is_Big then
             null;   --  nothing to do

--- a/src/gnatcoll-strings_impl.adb
+++ b/src/gnatcoll-strings_impl.adb
@@ -741,7 +741,7 @@ package body GNATCOLL.Strings_Impl is
       -- "=" --
       ---------
 
-      function "=" (Left, Right : XString) return Boolean is
+      overriding function "=" (Left, Right : XString) return Boolean is
          B1, B2 : Char_Array;
          L1, L2 : Natural;
       begin

--- a/src/gnatcoll-strings_impl.ads
+++ b/src/gnatcoll-strings_impl.ads
@@ -356,7 +356,7 @@ package GNATCOLL.Strings_Impl is
       --  or   if Str = Null_Xstring then
 
       type Indefinite_Char_Array is
-         array (Positive range <>) of aliased Char_Type;
+         array (Positive range <>) of Char_Type;
       subtype Unconstrained_Char_Array is Indefinite_Char_Array (Positive);
       type Char_Array is access all Unconstrained_Char_Array;
       pragma Suppress_Initialization (Unconstrained_Char_Array);
@@ -662,7 +662,7 @@ package GNATCOLL.Strings_Impl is
       procedure Write
          (Self    : in out XString;
           Process : not null access procedure
-             (S    : not null access Indefinite_Char_Array;
+             (S    : in out Char_String;
               Last : in out Natural));
       --  Access the string contained in Self, and lets you change its
       --  contents. This is an efficient way to load a large file in an

--- a/src/gnatcoll-strings_impl.ads
+++ b/src/gnatcoll-strings_impl.ads
@@ -525,7 +525,7 @@ package GNATCOLL.Strings_Impl is
       ---------------
 
       function "=" (Left : XString;      Right : Char_String) return Boolean;
-      function "=" (Left : XString;      Right : XString) return Boolean;
+      overriding function "=" (Left : XString; Right : XString) return Boolean;
       function "=" (Left : Char_String;  Right : XString) return Boolean
          is (Right = Left);
 

--- a/src/gnatcoll-traces.ads
+++ b/src/gnatcoll-traces.ads
@@ -243,6 +243,7 @@ with Ada.Exceptions;
 with Ada.Characters.Handling;    use Ada.Characters.Handling;
 private with Ada.Finalization;
 
+with GNATCOLL.Counters;
 with GNATCOLL.VFS;           use GNATCOLL.VFS;
 with GNATCOLL.Atomic;        use GNATCOLL.Atomic;
 with GNATCOLL.Strings_Impl;
@@ -711,7 +712,8 @@ package GNATCOLL.Traces is
    package Msg_Strings is new GNATCOLL.Strings_Impl.Strings
       (SSize            => Typical_Msg_Size,
        Character_Type   => Character,
-       Character_String => String);
+       Character_String => String,
+       Counters         => GNATCOLL.Counters.Automatic_Counters);
    --  We assume that most messages (including decorators) will be less than
    --  this number of characters, and optimize the string creation for this.
    --  But we still support larger messages, at a cost of one memory


### PR DESCRIPTION
Various patches for GNATCOLL.Strings*
They optimize performance when not using atomic counters (by avoiding the use of types "with Atomic" aspect).
(Write) is a new subprogram to conveniently manipulate the content of the string. In particular, it optimizes performance when reading large buffers from files, by avoiding extra copies (memcpy).
I have the corresponding tests, but AdaCore's github no longer includes the tests at this point. Will contribute them when they are back.