### PR TITLE
Various patches

### DIFF
--- a/src/gnatcoll-asserts.adb
+++ b/src/gnatcoll-asserts.adb
@@ -187,7 +187,7 @@ package body GNATCOLL.Asserts is
                and then not ("<" (Left, Right) or else "=" (Left, Right))
             then
                Report.On_Assertion_Failed
-                  (Details  => Image (Left) & " = " & Image (Right),
+                  (Details  => Image (Left) & " <= " & Image (Right),
                    Msg      => Msg,
                    Location => Location,
                    Entity   => Entity);
@@ -208,7 +208,7 @@ package body GNATCOLL.Asserts is
                and then "<" (Left, Right)
             then
                Report.On_Assertion_Failed
-                  (Details  => Image (Left) & " = " & Image (Right),
+                  (Details  => Image (Left) & " >= " & Image (Right),
                    Msg      => Msg,
                    Location => Location,
                    Entity   => Entity);
@@ -229,7 +229,7 @@ package body GNATCOLL.Asserts is
                and then ("<" (Left, Right) or else "=" (Left, Right))
             then
                Report.On_Assertion_Failed
-                  (Details  => Image (Left) & " = " & Image (Right),
+                  (Details  => Image (Left) & " > " & Image (Right),
                    Msg      => Msg,
                    Location => Location,
                    Entity   => Entity);

--- a/src/gnatcoll-atomic.ads
+++ b/src/gnatcoll-atomic.ads
@@ -92,6 +92,12 @@ package GNATCOLL.Atomic is
    --      4 (thread 1 has read and incremented, then thread 2)
    --  If you use the other operations above, you always end up with 4.
 
+   function ">" (Left, Right : Atomic_Counter) return Boolean
+      is (System.Atomic_Counters.">" (Left, Right));
+   --  Compare two counters.
+   --  Note that by the time this function returns, and in a multi threaded
+   --  application, either of the two counters might have changed.
+
    function "="
       (Left, Right : Atomic_Counter) return Boolean
       renames System.Atomic_Counters."=";

--- a/src/gnatcoll-email-mailboxes.adb
+++ b/src/gnatcoll-email-mailboxes.adb
@@ -140,7 +140,7 @@ package body GNATCOLL.Email.Mailboxes is
    -- First --
    -----------
 
-   function First (Self : Mbox) return Cursor'Class is
+   overriding function First (Self : Mbox) return Cursor'Class is
    begin
       declare
          Cur : Cursor'Class := Mbox_Cursor'
@@ -159,7 +159,7 @@ package body GNATCOLL.Email.Mailboxes is
    -- Has_Element --
    -----------------
 
-   function Has_Element (Self : Mbox_Cursor) return Boolean is
+   overriding function Has_Element (Self : Mbox_Cursor) return Boolean is
    begin
       return Self.Stop <= Self.Max;
    end Has_Element;
@@ -168,7 +168,7 @@ package body GNATCOLL.Email.Mailboxes is
    -- Get_Message --
    -----------------
 
-   procedure Get_Message
+   overriding procedure Get_Message
      (Self : in out Mbox_Cursor;
       Box  : Mailbox'Class;
       Msg  : out Message)
@@ -202,7 +202,7 @@ package body GNATCOLL.Email.Mailboxes is
    -- Next --
    ----------
 
-   procedure Next
+   overriding procedure Next
      (Self : in out Mbox_Cursor;
       Box  : Mailbox'Class)
    is
@@ -310,7 +310,7 @@ package body GNATCOLL.Email.Mailboxes is
    -- Finalize --
    --------------
 
-   procedure Finalize (Self : in out Mailbox) is
+   overriding procedure Finalize (Self : in out Mailbox) is
       pragma Unreferenced (Self);
    begin
       null;
@@ -320,7 +320,7 @@ package body GNATCOLL.Email.Mailboxes is
    -- Finalize --
    --------------
 
-   procedure Finalize (Self : in out Mbox) is
+   overriding procedure Finalize (Self : in out Mbox) is
    begin
       if Self.On_Close /= null and then Self.Fp /= null then
          Self.On_Close (Self.Fp);
@@ -381,7 +381,7 @@ package body GNATCOLL.Email.Mailboxes is
    -- First --
    -----------
 
-   function First (Self : Stored_Mailbox) return Cursor'Class is
+   overriding function First (Self : Stored_Mailbox) return Cursor'Class is
    begin
       return First (Self, Recurse => False);
    end First;
@@ -445,7 +445,7 @@ package body GNATCOLL.Email.Mailboxes is
    -- Has_Element --
    -----------------
 
-   function Has_Element
+   overriding function Has_Element
      (Self : Stored_Mailbox_Cursor) return Boolean
    is
    begin
@@ -456,7 +456,7 @@ package body GNATCOLL.Email.Mailboxes is
    -- Get_Message --
    -----------------
 
-   procedure Get_Message
+   overriding procedure Get_Message
      (Self : in out Stored_Mailbox_Cursor;
       Box  : Mailbox'Class;
       Msg  : out Message)
@@ -489,7 +489,7 @@ package body GNATCOLL.Email.Mailboxes is
    -- Next --
    ----------
 
-   procedure Next
+   overriding procedure Next
      (Self : in out Stored_Mailbox_Cursor;
       Box  : Mailbox'Class)
    is

--- a/src/gnatcoll-email-mailboxes.ads
+++ b/src/gnatcoll-email-mailboxes.ads
@@ -257,7 +257,7 @@ private
       --  Cache the current message
    end record;
 
-   procedure Finalize (Self : in out Mailbox);
+   overriding procedure Finalize (Self : in out Mailbox);
    pragma Finalize_Storage_Only (Mailbox);
 
    type Mbox is new Mailbox with record

--- a/src/gnatcoll-email.adb
+++ b/src/gnatcoll-email.adb
@@ -99,7 +99,7 @@ package body GNATCOLL.Email is
    -- "=" --
    ---------
 
-   function "=" (Addr1, Addr2 : Email_Address) return Boolean is
+   overriding function "=" (Addr1, Addr2 : Email_Address) return Boolean is
    begin
       return To_Lower (To_String (Addr1.Address))
            = To_Lower (To_String (Addr2.Address));
@@ -438,7 +438,7 @@ package body GNATCOLL.Email is
    -- Adjust --
    ------------
 
-   procedure Adjust (Msg : in out Message) is
+   overriding procedure Adjust (Msg : in out Message) is
    begin
       if Msg.Contents /= null then
          Msg.Contents.Ref_Count := Msg.Contents.Ref_Count + 1;
@@ -449,7 +449,7 @@ package body GNATCOLL.Email is
    -- Finalize --
    --------------
 
-   procedure Finalize (Msg : in out Message) is
+   overriding procedure Finalize (Msg : in out Message) is
       procedure Unchecked_Free is new Ada.Unchecked_Deallocation
         (Message_Record, Message_Access);
       Contents : Message_Access := Msg.Contents;
@@ -2169,7 +2169,7 @@ package body GNATCOLL.Email is
    -- Adjust --
    ------------
 
-   procedure Adjust   (H : in out Header) is
+   overriding procedure Adjust   (H : in out Header) is
    begin
       if H.Contents /= null then
          H.Contents.Ref_Count := H.Contents.Ref_Count + 1;
@@ -2180,7 +2180,7 @@ package body GNATCOLL.Email is
    -- Finalize --
    --------------
 
-   procedure Finalize (H : in out Header) is
+   overriding procedure Finalize (H : in out Header) is
       procedure Unchecked_Free is new Ada.Unchecked_Deallocation
         (Header_Record, Header_Access);
    begin

--- a/src/gnatcoll-io-native.adb
+++ b/src/gnatcoll-io-native.adb
@@ -60,7 +60,7 @@ package body GNATCOLL.IO.Native is
    -- Dispatching_Create --
    ------------------------
 
-   function Dispatching_Create
+   overriding function Dispatching_Create
      (Ref       : not null access Native_File_Record;
       Full_Path : FS_String) return File_Access
    is
@@ -73,7 +73,7 @@ package body GNATCOLL.IO.Native is
    -- To_UTF8 --
    -------------
 
-   function To_UTF8
+   overriding function To_UTF8
      (Ref  : not null access Native_File_Record;
       Path : FS_String) return String
    is
@@ -86,7 +86,7 @@ package body GNATCOLL.IO.Native is
    -- From_UTF8 --
    ---------------
 
-   function From_UTF8
+   overriding function From_UTF8
      (Ref  : not null access Native_File_Record;
       Path : String) return FS_String
    is
@@ -235,7 +235,7 @@ package body GNATCOLL.IO.Native is
    -- Is_Local --
    --------------
 
-   function Is_Local (File : Native_File_Record) return Boolean is
+   overriding function Is_Local (File : Native_File_Record) return Boolean is
       pragma Unreferenced (File);
    begin
       return True;
@@ -245,7 +245,7 @@ package body GNATCOLL.IO.Native is
    -- Get_FS --
    ------------
 
-   function Get_FS
+   overriding function Get_FS
      (File : not null access Native_File_Record) return FS_Type
    is
       pragma Unreferenced (File);
@@ -257,7 +257,7 @@ package body GNATCOLL.IO.Native is
    -- Resolve_Symlinks --
    ----------------------
 
-   procedure Resolve_Symlinks
+   overriding procedure Resolve_Symlinks
      (File : not null access Native_File_Record)
    is
       Is_Dir_Path : Boolean;
@@ -309,7 +309,7 @@ package body GNATCOLL.IO.Native is
    -- Is_Regular_File --
    ---------------------
 
-   function Is_Regular_File
+   overriding function Is_Regular_File
      (File : not null access Native_File_Record) return Boolean is
    begin
       return GNAT.OS_Lib.Is_Regular_File (String (File.Full.all));
@@ -319,7 +319,7 @@ package body GNATCOLL.IO.Native is
    -- Size --
    ----------
 
-   function Size
+   overriding function Size
      (File : not null access Native_File_Record) return Long_Integer
    is
       Fd : constant GNAT.OS_Lib.File_Descriptor := GNAT.OS_Lib.Open_Read
@@ -337,7 +337,7 @@ package body GNATCOLL.IO.Native is
    -- Is_Directory --
    ------------------
 
-   function Is_Directory
+   overriding function Is_Directory
      (File : not null access Native_File_Record) return Boolean is
    begin
       if GNAT.OS_Lib.Directory_Separator = '\'
@@ -369,7 +369,7 @@ package body GNATCOLL.IO.Native is
    -- Is_Symbolic_Link --
    ----------------------
 
-   function Is_Symbolic_Link
+   overriding function Is_Symbolic_Link
      (File : not null access Native_File_Record) return Boolean is
    begin
       return GNAT.OS_Lib.Is_Symbolic_Link (String (File.Full.all));
@@ -383,7 +383,7 @@ package body GNATCOLL.IO.Native is
    --  Time zone cache, assuming that the OS will not change time zones while
    --  this partition is running.
 
-   function File_Time_Stamp
+   overriding function File_Time_Stamp
      (File : not null access Native_File_Record) return Ada.Calendar.Time
    is
       T      : constant GNAT.OS_Lib.OS_Time :=
@@ -418,7 +418,7 @@ package body GNATCOLL.IO.Native is
    -- Is_Readable --
    -----------------
 
-   function Is_Readable
+   overriding function Is_Readable
      (File : not null access Native_File_Record) return Boolean is
    begin
       return GNAT.OS_Lib.Is_Readable_File (String (File.Full.all));
@@ -428,7 +428,7 @@ package body GNATCOLL.IO.Native is
    -- Is_Writable --
    -----------------
 
-   function Is_Writable
+   overriding function Is_Writable
      (File : not null access Native_File_Record) return Boolean is
    begin
       return GNAT.OS_Lib.Is_Writable_File (String (File.Full.all));
@@ -438,7 +438,7 @@ package body GNATCOLL.IO.Native is
    -- Set_Writable --
    ------------------
 
-   procedure Set_Writable
+   overriding procedure Set_Writable
      (File  : not null access Native_File_Record;
       State : Boolean)
    is
@@ -456,7 +456,7 @@ package body GNATCOLL.IO.Native is
    -- Set_Readable --
    ------------------
 
-   procedure Set_Readable
+   overriding procedure Set_Readable
      (File  : not null access Native_File_Record;
       State : Boolean)
    is
@@ -474,7 +474,7 @@ package body GNATCOLL.IO.Native is
    -- Rename --
    ------------
 
-   procedure Rename
+   overriding procedure Rename
      (From    : not null access Native_File_Record;
       Dest    : not null access Native_File_Record;
       Success : out Boolean)
@@ -492,7 +492,7 @@ package body GNATCOLL.IO.Native is
    -- Copy --
    ----------
 
-   procedure Copy
+   overriding procedure Copy
      (From    : not null access Native_File_Record;
       Dest    : FS_String;
       Success : out Boolean)
@@ -511,7 +511,7 @@ package body GNATCOLL.IO.Native is
    -- Delete --
    ------------
 
-   procedure Delete
+   overriding procedure Delete
      (File    : not null access Native_File_Record;
       Success : out Boolean)
    is
@@ -523,7 +523,7 @@ package body GNATCOLL.IO.Native is
    -- Read_Whole_File --
    ---------------------
 
-   function Read_Whole_File
+   overriding function Read_Whole_File
      (File : not null access Native_File_Record)
       return GNAT.Strings.String_Access
    is
@@ -539,7 +539,7 @@ package body GNATCOLL.IO.Native is
    -- Read_Whole_File --
    ---------------------
 
-   function Read_Whole_File
+   overriding function Read_Whole_File
      (File : not null access Native_File_Record)
       return GNATCOLL.Strings.XString
    is
@@ -555,7 +555,7 @@ package body GNATCOLL.IO.Native is
    -- Open_Write --
    ----------------
 
-   procedure Open_Write
+   overriding procedure Open_Write
      (File   : not null access Native_File_Record;
       Append : Boolean := False;
       FD     : out GNAT.OS_Lib.File_Descriptor)
@@ -582,7 +582,7 @@ package body GNATCOLL.IO.Native is
    -- Close --
    -----------
 
-   procedure Close
+   overriding procedure Close
      (File    : not null access Native_File_Record;
       FD      : GNAT.OS_Lib.File_Descriptor;
       Success : out Boolean)
@@ -602,7 +602,7 @@ package body GNATCOLL.IO.Native is
    -- Change_Dir --
    ----------------
 
-   function Change_Dir
+   overriding function Change_Dir
      (Dir : not null access Native_File_Record)
       return Boolean
    is
@@ -619,7 +619,7 @@ package body GNATCOLL.IO.Native is
    -- Read_Dir --
    --------------
 
-   function Read_Dir
+   overriding function Read_Dir
      (Dir        : not null access Native_File_Record;
       Dirs_Only  : Boolean := False;
       Files_Only : Boolean := False) return GNAT.Strings.String_List
@@ -687,7 +687,7 @@ package body GNATCOLL.IO.Native is
    -- Make_Dir --
    --------------
 
-   function Make_Dir
+   overriding function Make_Dir
      (Dir       : not null access Native_File_Record;
       Recursive : Boolean) return Boolean is
    begin
@@ -708,7 +708,7 @@ package body GNATCOLL.IO.Native is
    -- Remove_Dir --
    ----------------
 
-   procedure Remove_Dir
+   overriding procedure Remove_Dir
      (Dir       : not null access Native_File_Record;
       Recursive : Boolean;
       Success   : out Boolean)
@@ -726,7 +726,7 @@ package body GNATCOLL.IO.Native is
    -- Copy_Dir --
    --------------
 
-   procedure Copy_Dir
+   overriding procedure Copy_Dir
      (From    : not null access Native_File_Record;
       Dest    : FS_String;
       Success : out Boolean)

--- a/src/gnatcoll-io-native.ads
+++ b/src/gnatcoll-io-native.ads
@@ -70,7 +70,7 @@ package GNATCOLL.IO.Native is
      (File : not null access Native_File_Record);
    overriding function Is_Regular_File
      (File : not null access Native_File_Record) return Boolean;
-   function Size
+   overriding function Size
      (File : not null access Native_File_Record) return Long_Integer;
    overriding function Is_Directory
      (File : not null access Native_File_Record) return Boolean;

--- a/src/gnatcoll-io-remote.adb
+++ b/src/gnatcoll-io-remote.adb
@@ -340,7 +340,7 @@ package body GNATCOLL.IO.Remote is
    -- Dispatching_Create --
    ------------------------
 
-   function Dispatching_Create
+   overriding function Dispatching_Create
      (Ref : not null access Remote_File_Record;
       Full_Path : FS_String) return File_Access
    is
@@ -352,7 +352,7 @@ package body GNATCOLL.IO.Remote is
    -- To_UTF8 --
    -------------
 
-   function To_UTF8
+   overriding function To_UTF8
      (Ref : not null access Remote_File_Record;
       Path : FS_String) return String
    is
@@ -365,7 +365,7 @@ package body GNATCOLL.IO.Remote is
    -- From_UTF8 --
    ---------------
 
-   function From_UTF8
+   overriding function From_UTF8
      (Ref : not null access Remote_File_Record;
       Path : String) return FS_String
    is
@@ -378,7 +378,7 @@ package body GNATCOLL.IO.Remote is
    -- Is_Local --
    --------------
 
-   function Is_Local (File : Remote_File_Record) return Boolean is
+   overriding function Is_Local (File : Remote_File_Record) return Boolean is
       pragma Unreferenced (File);
    begin
       return False;
@@ -388,7 +388,7 @@ package body GNATCOLL.IO.Remote is
    -- Get_FS --
    ------------
 
-   function Get_FS
+   overriding function Get_FS
      (File : not null access Remote_File_Record) return FS_Type
    is
    begin
@@ -401,7 +401,7 @@ package body GNATCOLL.IO.Remote is
    -- Resolve_Symlinks --
    ----------------------
 
-   procedure Resolve_Symlinks
+   overriding procedure Resolve_Symlinks
      (File : not null access Remote_File_Record)
    is
    begin
@@ -421,7 +421,7 @@ package body GNATCOLL.IO.Remote is
    -- Is_Regular_File --
    ---------------------
 
-   function Is_Regular_File
+   overriding function Is_Regular_File
      (File : not null access Remote_File_Record) return Boolean
    is
    begin
@@ -466,7 +466,7 @@ package body GNATCOLL.IO.Remote is
    -- Is_Directory --
    ------------------
 
-   function Is_Directory
+   overriding function Is_Directory
      (File : not null access Remote_File_Record) return Boolean
    is
    begin
@@ -489,7 +489,7 @@ package body GNATCOLL.IO.Remote is
    -- Is_Symbolic_Link --
    ----------------------
 
-   function Is_Symbolic_Link
+   overriding function Is_Symbolic_Link
      (File : not null access Remote_File_Record) return Boolean
    is
    begin
@@ -512,7 +512,7 @@ package body GNATCOLL.IO.Remote is
    -- File_Time_Stamp --
    ---------------------
 
-   function File_Time_Stamp
+   overriding function File_Time_Stamp
      (File : not null access Remote_File_Record) return Ada.Calendar.Time
    is
    begin
@@ -557,7 +557,7 @@ package body GNATCOLL.IO.Remote is
    -- Is_Writable --
    -----------------
 
-   function Is_Writable
+   overriding function Is_Writable
      (File : not null access Remote_File_Record) return Boolean is
    begin
       Ensure_Initialized (File);
@@ -579,7 +579,7 @@ package body GNATCOLL.IO.Remote is
    -- Set_Writable --
    ------------------
 
-   procedure Set_Writable
+   overriding procedure Set_Writable
      (File  : not null access Remote_File_Record;
       State : Boolean)
    is
@@ -605,7 +605,7 @@ package body GNATCOLL.IO.Remote is
    -- Set_Readable --
    ------------------
 
-   procedure Set_Readable
+   overriding procedure Set_Readable
      (File  : not null access Remote_File_Record;
       State : Boolean)
    is
@@ -631,7 +631,7 @@ package body GNATCOLL.IO.Remote is
    -- Rename --
    ------------
 
-   procedure Rename
+   overriding procedure Rename
      (From    : not null access Remote_File_Record;
       Dest    : not null access Remote_File_Record;
       Success : out Boolean)
@@ -662,7 +662,7 @@ package body GNATCOLL.IO.Remote is
    -- Copy --
    ----------
 
-   procedure Copy
+   overriding procedure Copy
      (From    : not null access Remote_File_Record;
       Dest    : FS_String;
       Success : out Boolean)
@@ -687,7 +687,7 @@ package body GNATCOLL.IO.Remote is
    -- Delete --
    ------------
 
-   procedure Delete
+   overriding procedure Delete
      (File    : not null access Remote_File_Record;
       Success : out Boolean)
    is
@@ -713,7 +713,7 @@ package body GNATCOLL.IO.Remote is
    -- Read_Whole_File --
    ---------------------
 
-   function Read_Whole_File
+   overriding function Read_Whole_File
      (File : not null access Remote_File_Record)
       return GNAT.Strings.String_Access
    is
@@ -737,7 +737,7 @@ package body GNATCOLL.IO.Remote is
    -- Read_Whole_File --
    ---------------------
 
-   function Read_Whole_File
+   overriding function Read_Whole_File
      (File : not null access Remote_File_Record)
       return GNATCOLL.Strings.XString
    is
@@ -761,7 +761,7 @@ package body GNATCOLL.IO.Remote is
    -- Open_Write --
    ----------------
 
-   procedure Open_Write
+   overriding procedure Open_Write
      (File    : not null access Remote_File_Record;
       Append  : Boolean := False;
       FD      : out GNAT.OS_Lib.File_Descriptor)
@@ -813,7 +813,7 @@ package body GNATCOLL.IO.Remote is
    -- Close --
    -----------
 
-   procedure Close
+   overriding procedure Close
      (File    : not null access Remote_File_Record;
       FD      : GNAT.OS_Lib.File_Descriptor;
       Success : out Boolean)
@@ -855,7 +855,7 @@ package body GNATCOLL.IO.Remote is
    -- Change_Dir --
    ----------------
 
-   function Change_Dir
+   overriding function Change_Dir
      (Dir : not null access Remote_File_Record) return Boolean
    is
    begin
@@ -878,7 +878,7 @@ package body GNATCOLL.IO.Remote is
    -- Read_Dir --
    --------------
 
-   function Read_Dir
+   overriding function Read_Dir
      (Dir            : not null access Remote_File_Record;
       Dirs_Only      : Boolean := False;
       Files_Only     : Boolean := False) return GNAT.Strings.String_List
@@ -905,7 +905,7 @@ package body GNATCOLL.IO.Remote is
    -- Make_Dir --
    --------------
 
-   function Make_Dir
+   overriding function Make_Dir
      (Dir       : not null access Remote_File_Record;
       Recursive : Boolean) return Boolean
    is
@@ -929,7 +929,7 @@ package body GNATCOLL.IO.Remote is
    -- Remove_Dir --
    ----------------
 
-   procedure Remove_Dir
+   overriding procedure Remove_Dir
      (Dir       : not null access Remote_File_Record;
       Recursive : Boolean;
       Success   : out Boolean)
@@ -954,7 +954,7 @@ package body GNATCOLL.IO.Remote is
    -- Copy_Dir --
    --------------
 
-   procedure Copy_Dir
+   overriding procedure Copy_Dir
      (From    : not null access Remote_File_Record;
       Dest    : FS_String;
       Success : out Boolean)

--- a/src/gnatcoll-mmap-system__unix.adb
+++ b/src/gnatcoll-mmap-system__unix.adb
@@ -22,6 +22,8 @@
 ------------------------------------------------------------------------------
 
 with Ada.IO_Exceptions;
+with Ada.Unchecked_Conversion;
+with Interfaces.C;
 with System; use System;
 
 with GNAT.OS_Lib; use GNAT.OS_Lib;
@@ -42,6 +44,9 @@ package body GNATCOLL.Mmap.System is
    MAP_SHARED  : constant Mmap_Flags := 16#01#;
    MAP_PRIVATE : constant Mmap_Flags := 16#02#;
 
+   function From_Advice is new Ada.Unchecked_Conversion
+      (Use_Advice, Interfaces.C.int);
+
    function Mmap (Start  : Standard.System.Address := Null_Address;
                   Length : File_Size;
                   Prot   : Mmap_Prot := PROT_READ;
@@ -56,8 +61,7 @@ package body GNATCOLL.Mmap.System is
 
    procedure Madvise (Addr   : Standard.System.Address;
                       Length : File_Size;
-                      Advice : Use_Advice);
-   pragma Import (C, Madvise, "gnatcoll_madvise");
+                      Advice : Use_Advice) with Inline;
    --  Allows a process that has knowledge of its memory behavior to
    --  describe it to the system. This advice applies to the mapped
    --  region at address Addr, and for the given Length. If Length
@@ -70,6 +74,23 @@ package body GNATCOLL.Mmap.System is
    function Is_Mapping_Available return Boolean;
    --  Wheter memory mapping is actually available on this system. It is an
    --  error to use Create_Mapping and Dispose_Mapping if this is False.
+
+   -------------
+   -- Madvise --
+   -------------
+
+   procedure Madvise (Addr   : Standard.System.Address;
+                      Length : File_Size;
+                      Advice : Use_Advice)
+   is
+      procedure Internal
+         (Addr   : Standard.System.Address;
+          Length : File_Size;
+          Advice : Interfaces.C.int);
+      pragma Import (C, Internal, "gnatcoll_madvise");
+   begin
+      Internal (Addr, Length, From_Advice (Advice));
+   end Madvise;
 
    ---------------
    -- Open_Read --

--- a/src/gnatcoll-mmap.ads
+++ b/src/gnatcoll-mmap.ads
@@ -146,6 +146,7 @@ package GNATCOLL.Mmap is
       (Use_Normal,
        Use_Random,
        Use_Sequential);
+   for Use_Advice'Size use Interfaces.C.int'Size;
    for Use_Advice use
       (Use_Normal      => 1,
        Use_Random      => 2,

--- a/src/gnatcoll-storage_pools-alignment.adb
+++ b/src/gnatcoll-storage_pools-alignment.adb
@@ -36,7 +36,7 @@ package body GNATCOLL.Storage_Pools.Alignment is
    -- Allocate --
    --------------
 
-   procedure Allocate
+   overriding procedure Allocate
      (Pool         : in out Unbounded_No_Reclaim_Align_Pool;
       Address      : out System.Address;
       Storage_Size : Storage_Count;
@@ -77,7 +77,7 @@ package body GNATCOLL.Storage_Pools.Alignment is
    -- Deallocate --
    ----------------
 
-   procedure Deallocate
+   overriding procedure Deallocate
      (Pool         : in out Unbounded_No_Reclaim_Align_Pool;
       Address      : System.Address;
       Storage_Size : Storage_Count;
@@ -114,7 +114,7 @@ package body GNATCOLL.Storage_Pools.Alignment is
    -- Storage_Size --
    ------------------
 
-   function Storage_Size
+   overriding function Storage_Size
      (Pool  : Unbounded_No_Reclaim_Align_Pool) return Storage_Count
    is
       pragma Unreferenced (Pool);

--- a/src/gnatcoll-storage_pools-alignment.ads
+++ b/src/gnatcoll-storage_pools-alignment.ads
@@ -48,17 +48,17 @@ private
      (Alignment : System.Storage_Elements.Storage_Count)
      is new System.Storage_Pools.Root_Storage_Pool with null record;
 
-   function Storage_Size
+   overriding function Storage_Size
      (Pool : Unbounded_No_Reclaim_Align_Pool)
       return System.Storage_Elements.Storage_Count;
 
-   procedure Allocate
+   overriding procedure Allocate
      (Pool         : in out Unbounded_No_Reclaim_Align_Pool;
       Address      : out System.Address;
       Storage_Size : System.Storage_Elements.Storage_Count;
       Alignment    : System.Storage_Elements.Storage_Count);
 
-   procedure Deallocate
+   overriding procedure Deallocate
      (Pool         : in out Unbounded_No_Reclaim_Align_Pool;
       Address      : System.Address;
       Storage_Size : System.Storage_Elements.Storage_Count;

--- a/src/gnatcoll-storage_pools-headers.adb
+++ b/src/gnatcoll-storage_pools-headers.adb
@@ -114,8 +114,14 @@ package body GNATCOLL.Storage_Pools.Headers is
          function Header_Of
             (Element : Element_Access) return access Extra_Header
          is
-            F : constant Integer := Element.all'Finalization_Size;
-            --  If the element_type is a controlled type, this constant will
+            F : Integer;
+         begin
+            if Element = null then
+               return null;
+            end if;
+
+            F := Element.all'Finalization_Size;
+            --  If the element_type is a controlled type, this will
             --  be the number of extra bytes requested by the compiler in
             --  calls to Allocate and Deallocate (see the memory layout
             --  description in the specs).
@@ -125,16 +131,11 @@ package body GNATCOLL.Storage_Pools.Headers is
             --  Header_Of so we need to take them into account when looking
             --  for the our own header.
 
-            H : constant access Extra_Header :=
-               (if Element = null
-                then null
-                else Convert
-                   (Address_Header_Of
-                      (Element.all'Address
-                       - Storage_Offset (F)
-                       - Element_Type'Descriptor_Size)));
-         begin
-            return H;
+            return Convert
+               (Address_Header_Of
+                  (Element.all'Address
+                   - Storage_Offset (F)
+                   - Element_Type'Descriptor_Size));
          end Header_Of;
 
       end Typed;

--- a/src/gnatcoll-utils.ads
+++ b/src/gnatcoll-utils.ads
@@ -27,6 +27,7 @@
 pragma Ada_2012;
 
 with Ada.Calendar.Time_Zones; use Ada.Calendar;
+with Ada.Characters.Handling;
 with Ada.Strings.Unbounded;
 with GNAT.Calendar;
 with GNAT.Expect;
@@ -210,6 +211,31 @@ package GNATCOLL.Utils is
    --  enabled (for systems that share dos files).
    --  CR/LF sequences are replaced by LF chars.
 
+   function Predicate
+      (Text : String;
+        Predicate : access function (Item : Character) return Boolean)
+      return Boolean
+      is (for all C of Text => Predicate (C));
+   --  Whether all characters in Text match Predicate.
+   --  This can be used with the various utilities in Ada.Characters.Handling,
+   --  for instance to check whether a string is made up of only lower case
+   --  characters.
+
+   function Is_Alphanumeric (Text : String) return Boolean
+     is (Predicate (Text, Ada.Characters.Handling.Is_Alphanumeric'Access));
+   function Is_Lower (Text : String) return Boolean
+     is (Predicate (Text, Ada.Characters.Handling.Is_Lower'Access));
+   function Is_Upper (Text : String) return Boolean
+     is (Predicate (Text, Ada.Characters.Handling.Is_Upper'Access));
+
+   function Is_Identifier (C : Character) return Boolean
+      is (C = '_' or else Ada.Characters.Handling.Is_Alphanumeric (C));
+   function Is_Identifier (Text : String) return Boolean
+      is (Predicate (Text, Is_Identifier'Access));
+   --  Whether C is a valid character for an identifier (in most programming
+   --  languages). It doesn't check whether the identifier starts with an
+   --  underscore for instance, just whether the characters would be valid.
+
    ------------
    -- Expect --
    ------------
@@ -251,6 +277,13 @@ package GNATCOLL.Utils is
    --  The input date is assumed to be in UTC unless a timezone is specified
    --  as hours with a final "[+-]\d\d", or as hours and minutes with
    --  "[+-]\d\d\d\d" or "[+-]\d\d:\d\d"
+   --
+   --  The output date is always returned for the UTC time zone.
+   --  So if you are in GMT+12 and you parse "2017-01-01T11:00:00", the
+   --  result date will be:  year=2016, month=12, day=31, time=23:00:00.
+   --  If you want to spit the resulting time to extract the components,
+   --  you should use:
+   --     Ada.Calendar.Formatting.Split (.., Time_Zone => 0);
 
    function Truncate
      (Date : Time; Time_Zone : Time_Zones.Time_Offset := 0) return Time;

--- a/src/gnatcoll-vfs.adb
+++ b/src/gnatcoll-vfs.adb
@@ -109,7 +109,7 @@ package body GNATCOLL.VFS is
    -- "=" --
    ---------
 
-   function "=" (File1, File2 : Virtual_File) return Boolean is
+   overriding function "=" (File1, File2 : Virtual_File) return Boolean is
    begin
       --  Test for the same pointer to actual value (or both null)
       if File1.Value = File2.Value then
@@ -1812,7 +1812,7 @@ package body GNATCOLL.VFS is
    -- Finalize --
    --------------
 
-   procedure Finalize (File : in out Virtual_File) is
+   overriding procedure Finalize (File : in out Virtual_File) is
       Value : GNATCOLL.IO.File_Access := File.Value;
    begin
       File.Value := null;  --  Make Finalize idempotent
@@ -1825,7 +1825,7 @@ package body GNATCOLL.VFS is
    -- Adjust --
    ------------
 
-   procedure Adjust (File : in out Virtual_File) is
+   overriding procedure Adjust (File : in out Virtual_File) is
    begin
       if File.Value /= null then
          Ref (File.Value);

--- a/src/gnatcoll-vfs.ads
+++ b/src/gnatcoll-vfs.ads
@@ -230,6 +230,8 @@ package GNATCOLL.VFS is
    --  are not resolved there by default, unless you specify Resolve_Links to
    --  True.
    --  The returned value can be used to recreate a Virtual_File instance.
+   --  If file names are case insensitive, the normalized name will always
+   --  be all lower cases.
 
    function Full_Name
      (File      : Virtual_File;
@@ -241,6 +243,7 @@ package GNATCOLL.VFS is
    --  Return a Hash_Type computed from the full name of the given VFS.
    --  Could be used to instantiate an Ada 2005 container that uses a VFS as
    --  key and requires a hash function.
+   --  See File_Sets below.
 
    function File_Extension
      (File      : Virtual_File;
@@ -328,7 +331,7 @@ package GNATCOLL.VFS is
    function Size (File : Virtual_File) return Long_Integer;
    --  The size of the file
 
-   function "=" (File1, File2 : Virtual_File) return Boolean;
+   overriding function "=" (File1, File2 : Virtual_File) return Boolean;
    --  Overloading of the standard operator
 
    function "<" (File1, File2 : Virtual_File) return Boolean;
@@ -613,8 +616,8 @@ private
    end record;
 
    pragma Finalize_Storage_Only (Virtual_File);
-   procedure Finalize (File : in out Virtual_File);
-   procedure Adjust (File : in out Virtual_File);
+   overriding procedure Finalize (File : in out Virtual_File);
+   overriding procedure Adjust (File : in out Virtual_File);
 
    type Writable_File is record
       File     : Virtual_File;

--- a/src/gnatcoll_support.c
+++ b/src/gnatcoll_support.c
@@ -17,6 +17,7 @@
 
 #include <sys/stat.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <string.h>
 
 #ifdef _WIN32
@@ -190,7 +191,7 @@ __gnatcoll_get_tmp_dir (void)
  ************************************************************************/
 
 #ifdef ATOMIC_INTRINSICS
-int gnatcoll_sync_bool_compare_and_swap_access
+bool gnatcoll_sync_bool_compare_and_swap_access
   (void** ptr, void* oldval, void* newval)
 {
    return __sync_bool_compare_and_swap(ptr, oldval, newval);


### PR DESCRIPTION
They mostly fix warnings in various compilation modes, though a few introduce new functions that are needed for later patches to GNATCOLL.Strings and GNATCOLL.SQL