### PR TITLE
Add shebang for an executable script

### DIFF
--- a/examples/library/build.sh
+++ b/examples/library/build.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 cd obj
 
 # Create the database from the schema (remove the old one, just in case)


### PR DESCRIPTION
The executable shell script examples/library/build.sh is run by
testsuite/sql/__init__.py, but may be run manually as an example.