### PR TITLE
Replace obsolete file() constructor with a context manager.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,8 @@ copyright = get_copyright()
 
 def get_version():
     """Extract the version from configure.in"""
-    return file("../version_information").read().strip()
+    with open ("../version_information") as f:
+        return f.readline().strip()
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the


### PR DESCRIPTION
Replace file(), specific to python2, with a context manager that also
closes the file after use.