### PR TITLE
Only copy Library_Options to Linker'Linker_Options for static kinds

### DIFF
--- a/gnatcoll.gpr
+++ b/gnatcoll.gpr
@@ -272,7 +272,12 @@ project GnatColl is
    end Naming;
 
    package Linker is
-      for Linker_Options use Extra_Libs;
+      case Library_Type is
+         when "relocatable" =>
+            null;
+         when "static" | "static-pic" =>
+            for Linker_Options use Extra_Libs;
+      end case;
    end Linker;
 
    package Install is


### PR DESCRIPTION
A program embedding a static library must be linked with indirect
dependencies, but a shared library is already linked with
Library_Options, and a program linking with it does not need to repeat
indirect dependencies. Overlinking even causes maintenance problems.