### PR TITLE
Link with libdl on unix OS

### DIFF
--- a/gnatcoll.gpr
+++ b/gnatcoll.gpr
@@ -95,6 +95,12 @@ project GnatColl is
                null;
          end case;
    end case;
+   case OS is
+      when "unix" =>
+         Extra_Libs := Extra_Libs & ("-ldl"); --  For gnatcoll.plugins
+      when others =>
+         null;
+   end case;
 
    So_Ext := "";
    case OS is


### PR DESCRIPTION
gnatcoll-plugins__unix.adb references libdl.so.  The -ldl linker
option has been lost by commit
6fe0fbee464d986469f9f7245a94b66b212828be when the old Makefile has
been converted to gprbuild.