### PR TITLE
Support Process_State on OpenBSD

### DIFF
--- a/src/os/unix/process-wrappers.c
+++ b/src/os/unix/process-wrappers.c
@@ -141,10 +141,19 @@ int __gnatcoll_init_sigchld_monitoring()
  * */
 int __gnatcoll_process_state(int pid)
 {
+#ifdef __OpenBSD__
+   int status;
+   pid = waitpid (pid, &status, WNOHANG);
+   if (pid == 0) { return 0; };
+   if (pid == -1 || WIFEXITED(status)) { return -2; };
+   /* return -1 is not possible since waitpid does the wait */
+   return 0;
+#else
    siginfo_t infop;
    int result;
    infop.si_pid = 0;
    result = waitid (P_PID, pid, &infop, WEXITED | WNOHANG | WNOWAIT);
    if (result == -1) { return -2; };
    if (infop.si_pid != 0) { return -1; } else { return 0; };
+#endif
 }


### PR DESCRIPTION
OpenBSD doesn't have waitid, so we have to use waitpid.  The semantics
of Process_State, which leaves a terminated child process in a
waitable condition, are not readily achievable on OpenBSD.  The best
we can do is return 0 or -2 based on whether the child process has
terminated or not.