### PR TITLE
use short-circuit where possible

### DIFF
--- a/src/gnatcoll-coders-base64.adb
+++ b/src/gnatcoll-coders-base64.adb
@@ -333,7 +333,7 @@ package body GNATCOLL.Coders.Base64 is
 
    overriding function Finished (Coder : Decoder_Type) return Boolean is
    begin
-      return Coder.Finish and not Coder.Has;
+      return Coder.Finish and then not Coder.Has;
    end Finished;
 
    -----------

--- a/src/gnatcoll-email.adb
+++ b/src/gnatcoll-email.adb
@@ -154,7 +154,7 @@ package body GNATCOLL.Email is
 
    function Is_Whitespace (Char : Character) return Boolean is
    begin
-      return Char = ' ' or Char = ASCII.HT;
+      return Char = ' ' or else Char = ASCII.HT;
    end Is_Whitespace;
 
    ----------------------
@@ -1297,7 +1297,7 @@ package body GNATCOLL.Email is
          end if;
 
       else
-         if MIME_Type /= "" and not Prepend then
+         if MIME_Type /= "" and then not Prepend then
             Replace_Header (Msg, H_CT);
             if H_CTE = Null_Header then
                Delete_Headers (Msg, Content_Transfer_Encoding);

--- a/src/gnatcoll-io-remote-windows.adb
+++ b/src/gnatcoll-io-remote-windows.adb
@@ -276,7 +276,7 @@ package body GNATCOLL.IO.Remote.Windows is
       Exec.Execute_Remotely (Args, Output, Status);
       Free (Args);
 
-      if Status and Output /= null then
+      if Status and then Output /= null then
          S := GNATCOLL.Utils.Split (Output.all, ' ');
 
          begin

--- a/src/gnatcoll-io-remote.adb
+++ b/src/gnatcoll-io-remote.adb
@@ -54,7 +54,7 @@ package body GNATCOLL.IO.Remote is
    begin
       --  Regexps might return file strings with a trailing CR or LF. Let's
       --  remove those before creating the File record.
-      while Path (Last) = ASCII.CR or Path (Last) = ASCII.LF loop
+      while Path (Last) = ASCII.CR or else Path (Last) = ASCII.LF loop
          Last := Last - 1;
       end loop;
 

--- a/src/gnatcoll-memory.adb
+++ b/src/gnatcoll-memory.adb
@@ -110,7 +110,7 @@ package body GNATCOLL.Memory is
    procedure Free (Ptr : System.Address) is
    begin
 
-      if Ptr /= System.Null_Address and not Memory_Check then
+      if Ptr /= System.Null_Address and then not Memory_Check then
          if Memory_Monitor then
 
             Initialize_System_Memory_Debug_Pool;
@@ -287,9 +287,8 @@ package body GNATCOLL.Memory is
 
       Memory_Check := Disable_Free;
 
-      if Activate_Monitor and not Memory_Monitor then
-         Initialize_System_Memory_Debug_Pool
-           (Has_Unhandled_Memory => True);
+      if Activate_Monitor and then not Memory_Monitor then
+         Initialize_System_Memory_Debug_Pool (Has_Unhandled_Memory => True);
          Memory_Monitor := True;
       end if;
 

--- a/src/gnatcoll-mmap.adb
+++ b/src/gnatcoll-mmap.adb
@@ -409,7 +409,7 @@ package body GNATCOLL.Mmap is
 
    function Is_Mutable (Region : Mapped_Region) return Boolean is
    begin
-      return Region.Mutable or Region.Write;
+      return Region.Mutable or else Region.Write;
    end Is_Mutable;
 
    ----------------

--- a/src/gnatcoll-opt_parse.adb
+++ b/src/gnatcoll-opt_parse.adb
@@ -149,7 +149,7 @@ package body GNATCOLL.Opt_Parse is
      (Self : Flag_Parser) return String
    is
    begin
-      if Self.Long /= "" and Self.Short /= "" then
+      if Self.Long /= "" and then Self.Short /= "" then
          return
            "[" & To_String (Self.Long) & "|" & To_String (Self.Short) & "]";
       elsif Self.Long /= "" then
@@ -166,7 +166,7 @@ package body GNATCOLL.Opt_Parse is
      (Self : Flag_Parser) return String
    is
    begin
-      if Self.Long /= "" and Self.Short /= "" then
+      if Self.Long /= "" and then Self.Short /= "" then
          return To_String (Self.Long) & ", " & To_String (Self.Short);
       elsif Self.Long /= "" then
          return To_String (Self.Long);
@@ -789,10 +789,10 @@ package body GNATCOLL.Opt_Parse is
       end Get;
 
    begin
-      if Long = "" and Short = "" then
+      if Long = "" and then Short = "" then
          raise Opt_Parse_Error
            with "A long or short flag must be provided for Parse_Flag";
-      elsif Long = "" and Name = "" then
+      elsif Long = "" and then Name = "" then
          raise Opt_Parse_Error
            with "Either Long or Name must be provided for Parse_Flag";
       elsif Enabled then
@@ -854,7 +854,7 @@ package body GNATCOLL.Opt_Parse is
            (if Name /= "" then Name else To_Upper (+Self.Name));
       begin
          if Usage_Text = "" then
-            if Long /= "" and Short /= "" then
+            if Long /= "" and then Short /= "" then
                return "[" & Long & "|" & Short & " " & Usage_Name & "]";
             elsif Long /= "" then
                return "[" & Long & " " & Usage_Name & "]";
@@ -872,7 +872,7 @@ package body GNATCOLL.Opt_Parse is
         (Dummy : Option_Parser) return String
       is
       begin
-         if Long /= "" and Short /= "" then
+         if Long /= "" and then Short /= "" then
             return Long & ", " & Short;
          elsif Long /= "" then
             return Long;
@@ -932,10 +932,10 @@ package body GNATCOLL.Opt_Parse is
       end Parse_Args;
 
    begin
-      if Long = "" and Short = "" then
+      if Long = "" and then Short = "" then
          raise Opt_Parse_Error
            with "A long or short flag must be provided for Parse_Option";
-      elsif Long = "" and Name = "" then
+      elsif Long = "" and then Name = "" then
          raise Opt_Parse_Error
            with "Either Long or Name must be provided for Parse_Option";
       elsif Enabled then
@@ -998,10 +998,10 @@ package body GNATCOLL.Opt_Parse is
       renames Internal_Option.Get;
 
    begin
-      if Long = "" and Short = "" then
+      if Long = "" and then Short = "" then
          raise Opt_Parse_Error
            with "A long or short flag must be provided for Parse_Enum_Option";
-      elsif Long = "" and Name = "" then
+      elsif Long = "" and then Name = "" then
          raise Opt_Parse_Error
            with "Either Long or Name must be provided for Parse_Enum_Option";
       end if;
@@ -1062,12 +1062,14 @@ package body GNATCOLL.Opt_Parse is
       is
       begin
          if Usage_Text = "" then
-            if Long /= "" and Short /= "" then
-               return "[" & Long & "|" & Short & " " & (+Self.Name) &
-                      " [" & (+Self.Name) & "...]]";
+            if Long /= "" and then Short /= "" then
+               return
+                 "[" & Long & "|" & Short & " " & (+Self.Name) & " [" &
+                 (+Self.Name) & "...]]";
             elsif Long /= "" then
-               return "[" & Long & " " & (+Self.Name) &
-                      " [" & (+Self.Name) & "...]]";
+               return
+                 "[" & Long & " " & (+Self.Name) & " [" & (+Self.Name) &
+                 "...]]";
             end if;
             return "[" & Short & " " & (+Self.Name) &
                    " [" & (+Self.Name) & "...]]";
@@ -1083,7 +1085,7 @@ package body GNATCOLL.Opt_Parse is
         (Dummy : Option_List_Parser) return String
       is
       begin
-         if Long /= "" and Short /= "" then
+         if Long /= "" and then Short /= "" then
             return Long & ", " & Short;
          elsif Long /= "" then
             return Long;
@@ -1192,10 +1194,10 @@ package body GNATCOLL.Opt_Parse is
       end Parse_Args;
 
    begin
-      if Long = "" and Short = "" then
+      if Long = "" and then Short = "" then
          raise Opt_Parse_Error
            with "A long or short flag must be provided for Parse_Option_List";
-      elsif Long = "" and Name = "" then
+      elsif Long = "" and then Name = "" then
          raise Opt_Parse_Error
            with "Either Long or Name must be provided for Parse_Option_List";
       elsif Enabled then
@@ -1349,7 +1351,7 @@ package body GNATCOLL.Opt_Parse is
       New_Pos     : out Parser_Return) return XString
    is
    begin
-      if Args (Pos) = Long or Args (Pos) = Short then
+      if Args (Pos) = Long or else Args (Pos) = Short then
          if Pos + 1 > Args'Last then
             raise Opt_Parse_Error with "Incomplete option";
          end if;

--- a/src/gnatcoll-projects.adb
+++ b/src/gnatcoll-projects.adb
@@ -4950,7 +4950,7 @@ package body GNATCOLL.Projects is
             Is_Limited_With  => Is_Limited_With);
       end if;
 
-      return Imports and Is_Limited_With;
+      return Imports and then Is_Limited_With;
 
    end Is_Limited_With;
 
@@ -4978,7 +4978,7 @@ package body GNATCOLL.Projects is
             Is_Limited_With  => Is_Limited_With);
       end if;
 
-      return Imports and Is_Limited_With;
+      return Imports and then Is_Limited_With;
    end Is_Limited_With;
 
    ----------
@@ -8452,7 +8452,7 @@ package body GNATCOLL.Projects is
          begin
             Trace (Me, "Output of gnatls is " & S);
 
-            if S = "" and Errors /= null then
+            if S = "" and then Errors /= null then
                Errors ("The output from '" & Gnatls & "-v' is empty");
             end if;
 
@@ -10265,9 +10265,7 @@ package body GNATCOLL.Projects is
    function Get_Environment
      (Self : Project_Type) return Project_Environment_Access is
    begin
-      if Self = No_Project
-        or Self.Data.Tree = null
-      then
+      if Self = No_Project or else Self.Data.Tree = null then
          return null;
       else
          return Self.Data.Tree.Env;

--- a/src/gnatcoll-scripts-utils.adb
+++ b/src/gnatcoll-scripts-utils.adb
@@ -215,7 +215,7 @@ package body GNATCOLL.Scripts.Utils is
             Max_Args := Max_Args * 2;
          end if;
 
-         if Start_With_Triple and End_With_Triple then
+         if Start_With_Triple and then End_With_Triple then
             New_Argv (New_Argc) :=
               new String'(Arg_String (Start_Idx + 3 .. Idx - 4));
          else


### PR DESCRIPTION
Dear Gnatcoll developers,

According to [adaic](https://www.adaic.org/resources/add_content/docs/95style/html/sec_5/5-5-5.html)
short circuit operators should be preferred.
However, in case of side effects in the second/right argument the replacement is NOT equivalent.

The rejuvenation library has detected where logical operators can be replaced by short-circuit ones
and replaced them.

Greetings,
   Pierre

Problem detected and solved by Rejuvenation-Ada crate
[![vote for Rejuvenation-Ada as The 2022 Ada Crate Of The Year](https://user-images.githubusercontent.com/18348654/191469254-1ca1f4a0-6242-43fa-94a2-f39f55817fdc.jpg)](https://github.com/AdaCore/Ada-SPARK-Crate-Of-The-Year/issues/15)



