### PR TITLE
Added functionality to access terminal window height (number of lines)

### DIFF
--- a/src/gnatcoll-terminal.adb
+++ b/src/gnatcoll-terminal.adb
@@ -432,4 +432,24 @@ package body GNATCOLL.Terminal is
          return Internal (Boolean'Pos (Self.FD = Stderr));
       end if;
    end Get_Width;
+
+
+   ---------------
+   -- Get_Lines --
+   ---------------
+
+   function Get_Lines (Self : Terminal_Info) return Integer is
+      function Internal (Stderr : Integer) return Integer;
+      pragma Import (C, Internal, "gnatcoll_terminal_lines");
+   begin
+      if Self.FD = File or else Self.Colors = Unsupported then
+         return -1;
+      else
+         return Internal (Boolean'Pos (Self.FD = Stderr));
+      end if;
+   end Get_Lines;
+
+
+
 end GNATCOLL.Terminal;
+

--- a/src/gnatcoll-terminal.adb
+++ b/src/gnatcoll-terminal.adb
@@ -433,7 +433,6 @@ package body GNATCOLL.Terminal is
       end if;
    end Get_Width;
 
-
    ---------------
    -- Get_Lines --
    ---------------
@@ -448,8 +447,6 @@ package body GNATCOLL.Terminal is
          return Internal (Boolean'Pos (Self.FD = Stderr));
       end if;
    end Get_Lines;
-
-
 
 end GNATCOLL.Terminal;
 

--- a/src/gnatcoll-terminal.ads
+++ b/src/gnatcoll-terminal.ads
@@ -184,6 +184,4 @@ private
       --  Whether the associated terminal is stdout (windows only)
    end record;
 
-
-
 end GNATCOLL.Terminal;

--- a/src/gnatcoll-terminal.ads
+++ b/src/gnatcoll-terminal.ads
@@ -140,6 +140,11 @@ package GNATCOLL.Terminal is
    --  Return the width of the terminal, or -1 if that width is either
    --  unknown or does not apply (as is the case for files for instance).
 
+   function Get_Lines (Self : Terminal_Info) return Integer;
+   --  Return the height of the terminal, or -1 if that height is either
+   --  unknown or does not apply (as is the case for files for instance).
+
+
    -----------
    -- Utils --
    -----------
@@ -179,5 +184,7 @@ private
       FD : FD_Type := Stdout;
       --  Whether the associated terminal is stdout (windows only)
    end record;
+
+
 
 end GNATCOLL.Terminal;

--- a/src/gnatcoll-terminal.ads
+++ b/src/gnatcoll-terminal.ads
@@ -144,7 +144,6 @@ package GNATCOLL.Terminal is
    --  Return the height of the terminal, or -1 if that height is either
    --  unknown or does not apply (as is the case for files for instance).
 
-
    -----------
    -- Utils --
    -----------

--- a/src/terminals.c
+++ b/src/terminals.c
@@ -124,7 +124,6 @@ int gnatcoll_terminal_width(int forStderr) {
       return (int)(csbiInfo.srWindow.Right-csbiInfo.srWindow.Left + 1); // window width
    }
    return -1;
-
 #else
 #ifdef TIOCGWINSZ
     struct winsize w;
@@ -145,7 +144,6 @@ int gnatcoll_terminal_lines(int forStderr) {
       return (int)(csbiInfo.srWindow.Bottom-csbiInfo.srWindow.Top + 1); // window height
    }
    return -1;
-
 #else
 #ifdef TIOCGWINSZ   // Linux/OSX
     struct winsize w;

--- a/src/terminals.c
+++ b/src/terminals.c
@@ -124,6 +124,7 @@ int gnatcoll_terminal_width(int forStderr) {
       return (int)(csbiInfo.srWindow.Right-csbiInfo.srWindow.Left + 1); // window width
    }
    return -1;
+   
 #else
 #ifdef TIOCGWINSZ
     struct winsize w;
@@ -144,6 +145,7 @@ int gnatcoll_terminal_lines(int forStderr) {
       return (int)(csbiInfo.srWindow.Bottom-csbiInfo.srWindow.Top + 1); // window height
    }
    return -1;
+   
 #else
 #ifdef TIOCGWINSZ   // Linux/OSX
     struct winsize w;
@@ -154,4 +156,3 @@ int gnatcoll_terminal_lines(int forStderr) {
 #endif
 #endif
 }
-

--- a/src/terminals.c
+++ b/src/terminals.c
@@ -1,25 +1,19 @@
 /*----------------------------------------------------------------------------
---                             G N A T C O L L                              --
+--                                  G N A T C O L L                         --
 --                                                                          --
---                     Copyright (C) 2014-2018, AdaCore                     --
+--                     Copyright (C) 2014-2017, AdaCore                     --
 --                                                                          --
--- This library is free software;  you can redistribute it and/or modify it --
--- under terms of the  GNU General Public License  as published by the Free --
--- Software  Foundation;  either version 3,  or (at your  option) any later --
--- version. This library is distributed in the hope that it will be useful, --
+-- This is free software;  you can redistribute it  and/or modify it  under --
+-- terms of the  GNU General Public License as published  by the Free Soft- --
+-- ware  Foundation;  either version 3,  or (at your option) any later ver- --
+-- sion.  This software is distributed in the hope  that it will be useful, --
 -- but WITHOUT ANY WARRANTY;  without even the implied warranty of MERCHAN- --
--- TABILITY or FITNESS FOR A PARTICULAR PURPOSE.                            --
---                                                                          --
--- As a special exception under Section 7 of GPL version 3, you are granted --
--- additional permissions described in the GCC Runtime Library Exception,   --
--- version 3.1, as published by the Free Software Foundation.               --
---                                                                          --
--- You should have received a copy of the GNU General Public License and    --
--- a copy of the GCC Runtime Library Exception along with this program;     --
--- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
--- <http://www.gnu.org/licenses/>.                                          --
---                                                                          --
------------------------------------------------------------------------------*/
+-- TABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public --
+-- License for  more details.  You should have  received  a copy of the GNU --
+-- General  Public  License  distributed  with  this  software;   see  file --
+-- COPYING3.  If not, go to http://www.gnu.org/licenses for a complete copy --
+-- of the license.                                                          --
+----------------------------------------------------------------------------*/
 
 #ifdef _WIN32
 #include <windows.h>

--- a/src/terminals.c
+++ b/src/terminals.c
@@ -121,9 +121,7 @@ int gnatcoll_terminal_width(int forStderr) {
       GetStdHandle (forStderr ? STD_ERROR_HANDLE : STD_OUTPUT_HANDLE);
    CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
    if (GetConsoleScreenBufferInfo (handle, &csbiInfo)) {
-      //return (int)csbiInfo.dwSize.X; // buffer width 
-      return (int)(csbiInfo.srWindow.Right
-						-csbiInfo.srWindow.Left + 1); // window width
+      return (int)(csbiInfo.srWindow.Right-csbiInfo.srWindow.Left + 1); // window width
    }
    return -1;
 
@@ -138,16 +136,13 @@ int gnatcoll_terminal_width(int forStderr) {
 #endif
 }
 
-
 int gnatcoll_terminal_lines(int forStderr) {
 #ifdef _WIN32  // MsWin
    const HANDLE handle =
       GetStdHandle (forStderr ? STD_ERROR_HANDLE : STD_OUTPUT_HANDLE);
    CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
    if (GetConsoleScreenBufferInfo (handle, &csbiInfo)) {
-      //return (int)csbiInfo.dwSize.Y; // buffer height (generally >> window height)
-      return (int)(csbiInfo.srWindow.Bottom
-						-csbiInfo.srWindow.Top + 1); // window height
+      return (int)(csbiInfo.srWindow.Bottom-csbiInfo.srWindow.Top + 1); // window height
    }
    return -1;
 

--- a/src/terminals.c
+++ b/src/terminals.c
@@ -1,19 +1,25 @@
 /*----------------------------------------------------------------------------
---                                  G N A T C O L L                         --
+--                             G N A T C O L L                              --
 --                                                                          --
---                     Copyright (C) 2014-2017, AdaCore                     --
+--                     Copyright (C) 2014-2018, AdaCore                     --
 --                                                                          --
--- This is free software;  you can redistribute it  and/or modify it  under --
--- terms of the  GNU General Public License as published  by the Free Soft- --
--- ware  Foundation;  either version 3,  or (at your option) any later ver- --
--- sion.  This software is distributed in the hope  that it will be useful, --
+-- This library is free software;  you can redistribute it and/or modify it --
+-- under terms of the  GNU General Public License  as published by the Free --
+-- Software  Foundation;  either version 3,  or (at your  option) any later --
+-- version. This library is distributed in the hope that it will be useful, --
 -- but WITHOUT ANY WARRANTY;  without even the implied warranty of MERCHAN- --
--- TABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public --
--- License for  more details.  You should have  received  a copy of the GNU --
--- General  Public  License  distributed  with  this  software;   see  file --
--- COPYING3.  If not, go to http://www.gnu.org/licenses for a complete copy --
--- of the license.                                                          --
-----------------------------------------------------------------------------*/
+-- TABILITY or FITNESS FOR A PARTICULAR PURPOSE.                            --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+-----------------------------------------------------------------------------*/
 
 #ifdef _WIN32
 #include <windows.h>

--- a/src/terminals.c
+++ b/src/terminals.c
@@ -121,7 +121,9 @@ int gnatcoll_terminal_width(int forStderr) {
       GetStdHandle (forStderr ? STD_ERROR_HANDLE : STD_OUTPUT_HANDLE);
    CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
    if (GetConsoleScreenBufferInfo (handle, &csbiInfo)) {
-      return (int)csbiInfo.dwSize.X;
+      //return (int)csbiInfo.dwSize.X; // buffer width 
+      return (int)(csbiInfo.srWindow.Right
+						-csbiInfo.srWindow.Left + 1); // window width
    }
    return -1;
 
@@ -135,3 +137,28 @@ int gnatcoll_terminal_width(int forStderr) {
 #endif
 #endif
 }
+
+
+int gnatcoll_terminal_lines(int forStderr) {
+#ifdef _WIN32  // MsWin
+   const HANDLE handle =
+      GetStdHandle (forStderr ? STD_ERROR_HANDLE : STD_OUTPUT_HANDLE);
+   CONSOLE_SCREEN_BUFFER_INFO csbiInfo;
+   if (GetConsoleScreenBufferInfo (handle, &csbiInfo)) {
+      //return (int)csbiInfo.dwSize.Y; // buffer height (generally >> window height)
+      return (int)(csbiInfo.srWindow.Bottom
+						-csbiInfo.srWindow.Top + 1); // window height
+   }
+   return -1;
+
+#else
+#ifdef TIOCGWINSZ   // Linux/OSX
+    struct winsize w;
+    ioctl(forStderr ? 1 : 0, TIOCGWINSZ, &w);
+    return w.ws_row; //  == lines
+#else
+    return -1;
+#endif
+#endif
+}
+

--- a/testsuite/tests/terminal/testlines.adb
+++ b/testsuite/tests/terminal/testlines.adb
@@ -1,0 +1,44 @@
+------------------------------------------------------------------------------
+--                                                                          --
+--                             G N A T C O L L                              --
+--                                                                          --
+--                     Copyright (C) 2006-2019, AdaCore                     --
+--                                                                          --
+-- This library is free software;  you can redistribute it and/or modify it --
+-- under terms of the  GNU General Public License  as published by the Free --
+-- Software  Foundation;  either version 3,  or (at your  option) any later --
+-- version. This library is distributed in the hope that it will be useful, --
+-- but WITHOUT ANY WARRANTY;  without even the implied warranty of MERCHAN- --
+-- TABILITY or FITNESS FOR A PARTICULAR PURPOSE.                            --
+--                                                                          --
+-- As a special exception under Section 7 of GPL version 3, you are granted --
+-- additional permissions described in the GCC Runtime Library Exception,   --
+-- version 3.1, as published by the Free Software Foundation.               --
+--                                                                          --
+-- You should have received a copy of the GNU General Public License and    --
+-- a copy of the GCC Runtime Library Exception along with this program;     --
+-- see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see    --
+-- <http://www.gnu.org/licenses/>.                                          --
+--                                                                          --
+------------------------------------------------------------------------------
+
+
+with GNATCOLL.Terminal;  use GNATCOLL.Terminal;
+with Ada.Text_IO;         use Ada.Text_IO;
+
+procedure testlines is
+	winrows, wincols: integer;
+	info: terminal_info;
+begin
+	info.init_for_stdout(auto);
+	wincols:=get_width(info);
+	winrows:=get_lines(info);
+
+	put("Lines:");
+	put(integer'image(winrows));
+	put(", Columns:");
+	put(integer'image(wincols));
+	new_line;
+
+end testlines;
+


### PR DESCRIPTION
For several of my apps I needed the window height.  This change has been tested on OSX, Windows, and several flavors of linux.
See, for example, "RetroArcade". This is one of my projects on GitHub.