### PR TITLE
term: check for error in TIOCGWINSZ ioctl

### DIFF
--- a/src/terminals.c
+++ b/src/terminals.c
@@ -128,8 +128,8 @@ int gnatcoll_terminal_width(int forStderr) {
 #else
 #ifdef TIOCGWINSZ
     struct winsize w;
-    ioctl(forStderr ? 1 : 0, TIOCGWINSZ, &w);
-    return w.ws_col;
+    int r = ioctl(forStderr ? 1 : 0, TIOCGWINSZ, &w);
+    return r < 0 ? -1 : w.ws_col;
 #else
     return -1;
 #endif


### PR DESCRIPTION
If the ioctl fails, the winsize struct will not be properly initialized and the return value of the function will be, accordingly, from uninitialized memory. As this is UB, it's best to check the return value from ioctl.

Fixes #82.

Thanks!